### PR TITLE
feat: export event types

### DIFF
--- a/packages/react-native-fast-ws/src/index.ts
+++ b/packages/react-native-fast-ws/src/index.ts
@@ -13,6 +13,11 @@ const manager = NitroModules.createHybridObject<WebSocketManager>('WebSocketMana
 
 type CustomEvent<T> = Event & T
 
+export type OpenEvent = Event
+export type MessageEvent = CustomEvent<{ message: string | ArrayBuffer }>
+export type ErrorEvent = CustomEvent<WebSocketError>
+export type CloseEvent = CustomEvent<WebSocketClosed>
+
 enum WebSocketReadyState {
   CONNECTING = 0,
   OPEN = 1,
@@ -27,10 +32,10 @@ const ABNORMAL_CLOSURE = 1006
 
 export class WebSocket extends EventTarget<
   {
-    open: Event
-    message: CustomEvent<{ message: string | ArrayBuffer }>
-    error: CustomEvent<WebSocketError>
-    close: CustomEvent<WebSocketClosed>
+    open: OpenEvent
+    message: MessageEvent
+    error: ErrorEvent
+    close: CloseEvent
   },
   {},
   'loose'


### PR DESCRIPTION
Currently when adding an event listener, inline functions work fine:

```ts
const ws = new WebSocket(...);

ws.addEventListener('message', (event) => {
  console.log(event.message); // Infers `event.message` ✅
});
```

But when extracting the function outside (in case we want to remove the listener later, for example), type cannot be inferred. Hence, this PR adds 4 new event types and exports them, to facilitate for the user to type his listeners:
- `OpenEvent`
- `MessageEvent`
- `ErrorEvent`
- `CloseEvent`

To be used like:
```tsx
import {
  WebSocket,
  OpenEvent,
  MessageEvent,
  ErrorEvent,
  CloseEvent
 } from 'react-native-fast-ws'

const ws = new WebSocket(...);

function App() {
  useEffect(() => {
    const onOpen = (event: OpenEvent) => {
      console.log('ws connection is open!');
    };

    const onMessage = (event: MessageEvent) => {
      console.log('Message received: ', event.message);
    };

    const onError = (event: ErrorEvent) => {
      console.log('Error: ', event.message);
    };

    const onClose = (event: CloseEvent) => {
      console.log('Code: ', event.code);
      console.log('Reason: ', event.reason);
    };

    ws.addEventListener('open', onOpen);
    ws.addEventListener('message', onMessage);
    ws.addEventListener('error', onError);
    ws.addEventListener('close', onClose);

    return () => {
      ws.removeEventListener('open', onOpen);
      ws.removeEventListener('message', onMessage);
      ws.removeEventListener('error', onError);
      ws.removeEventListener('close', onClose);
    };
  }, []);
}
```