### PR TITLE
feat: run streaming read/write operations in a Kotlin coroutine

### DIFF
--- a/packages/react-native-fast-io/android/src/main/java/com/margelo/nitro/fastio/HybridOutputStream.kt
+++ b/packages/react-native-fast-io/android/src/main/java/com/margelo/nitro/fastio/HybridOutputStream.kt
@@ -11,13 +11,8 @@ class HybridOutputStream(private val stream: OutputStream) : HybridOutputStreamS
         val bytes = ByteArray(buffer.size)
         byteBuffer.get(bytes)
 
-        return Promise<Unit>().apply {
-            try {
-                stream.write(bytes)
-                resolve(Unit)
-            } catch (e: Exception) {
-                reject(Error(e.message))
-            }
+        return Promise.async {
+            stream.write(bytes)
         }
     }
 

--- a/packages/react-native-fast-io/src/w3c/streams.ts
+++ b/packages/react-native-fast-io/src/w3c/streams.ts
@@ -59,18 +59,12 @@ export class CompressionStream implements globalThis.CompressionStream {
 
     const { readable, writable } = new TransformStream<Uint8Array>({
       transform(chunk, controller) {
-        try {
-          const compressedData = compressor.compress(chunk.buffer)
-          controller.enqueue(new Uint8Array(compressedData))
-        } catch (error) {
-          console.error(error)
-        }
+        const compressedData = compressor.compress(chunk.buffer)
+        controller.enqueue(new Uint8Array(compressedData))
       },
       flush(controller) {
-        console.log('flushing')
         const finalData = compressor.finalize()
         if (finalData.byteLength > 0) {
-          console.log(finalData.byteLength)
           controller.enqueue(new Uint8Array(finalData))
         }
       },


### PR DESCRIPTION
Would block JS thread otherwise