### PR TITLE
fix: cross-spawn high severity vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5827,8 +5827,9 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "license": "MIT",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
+      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "typescript": "^5.1.3",
     "vitest": "^2.1.1"
   },
+  "overrides": {
+    "cross-spawn": "7.0.5"
+  },
   "release-it": {
     "git": {
       "commitMessage": "chore: release ${version}",


### PR DESCRIPTION
In this PR i use overrides field in package.json file in order to set new version for cross-spawn package to solve the high severity vulnerability.

In future we should update eslint package. Now this version is not supported by vscode eslint extension.