### PR TITLE
fix: can't resolve types

### DIFF
--- a/packages/react-native-fast-io/package.json
+++ b/packages/react-native-fast-io/package.json
@@ -4,19 +4,29 @@
   "description": "Modern IO for React Native, built on top of Nitro and Web standards",
   "main": "./lib/commonjs/index",
   "module": "./lib/module/index",
-  "types": "./lib/typescript/commonjs/src/index.d.ts",
   "react-native": "./src/index",
   "source": "./src/index",
   "exports": {
     ".": {
-      "import": "./lib/module/index.js",
-      "require": "./lib/commonjs/index.js",
+      "import": {
+        "types": "./lib/typescript/module/src/index.d.ts",
+        "default": "./lib/module/index.js"
+      },
+      "require": {
+        "types": "./lib/typescript/commonjs/src/index.d.ts",
+        "default": "./lib/commonjs/index.js"
+      },
       "react-native": "./src/index"
     },
     "./*": {
-      "types": "./lib/typescript/commonjs/src/w3c/*.d.ts",
-      "import": "./lib/module/w3c/*.js",
-      "require": "./lib/commonjs/w3c/*.js",
+      "import": {
+        "types": "./lib/typescript/module/src/w3c/*.d.ts",
+        "default": "./lib/module/w3c/*.js"
+       },
+      "require": {
+        "types": "./lib/typescript/commonjs/src/w3c/*.d.ts",
+        "default": "./lib/commonjs/w3c/*.js"
+      },
       "react-native": "./src/w3c/*"
     }
   },


### PR DESCRIPTION
## What didn't work?

The types weren't getting resolved when I tried to import from `react-native-fast-io`. Other imports like `react-native-fast-io/ws` were fine. I've updated the `package.json` `exports` field to match this article: https://satya164-git-satya164-esm-satyas-projects-6ca38cef.vercel.app/posts/publishing-dual-module-esm-libraries#types-in-the-exports-field and now the types are working.

## How to test this?

1. Go to `packages/react-native-fast-io`
2. Call `npm pack` to generate a package file or use [yalc](https://github.com/wclr/yalc)
3. Create a new app and add the package there
4. Make sure the types are getting resolved properly when anything from `react-native-fast-io` is imported.